### PR TITLE
fix: do not use tags for normal prerelease dependency bump

### DIFF
--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -35,6 +35,8 @@ import { createRequire } from "module";
  * @param {Package[]} localDeps Array of local dependencies this package relies on.
  * @param {context|void} context The semantic-release context for this package's release (filled in once semantic-release runs).
  * @param {undefined|Result|false} result The result of semantic-release (object with lastRelease, nextRelease, commits, releases), false if this package was skipped (no changes or similar), or undefined if the package's release hasn't completed yet.
+ * @param {Object} _lastRelease The last release object for the package before its current release (set during anaylze-commit)
+ * @param {Object} _nextRelease The next release object (the release the package is releasing for this cycle) (set during generateNotes)
  */
 
 /**

--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -42,16 +42,40 @@ const getVersionFromTag = (pkg, tag) => {
 };
 
 /**
+ * Options for NextPreVersion
+ *
+ * @typedef {Object} NextPreVersionOptions
+ * @param {Array<string>|undefined} tags - will use the tags as a reference, overrides useGitTags
+ * @param {boolean|undefined} useGitTags - if true, will look up all git tags for this prerelease
+ */
+
+/**
  * Resolve next package version on prereleases.
  *
+ * Will resolve highest next version of either:
+ *
+ * 1. The last release for the package during this multi-release cycle
+ * 2. (if tag options provided):
+ *   a. the highest increment of the tags array provided
+ *   b. the highest increment of the gitTags for the prerelease
+ *
  * @param {Package} pkg Package object.
- * @param {Array<string>} tags Override list of tags from specific pkg and branch.
+ * @param {NextPreVersionOptions|undefined} options additional options
  * @returns {string|undefined} Next pkg version.
  * @internal
  */
-const getNextPreVersion = (pkg, tags) => {
+const getNextPreVersion = (pkg, options) => {
 	const tagFilters = [pkg._preRelease];
-	const lastVersion = pkg._lastRelease && pkg._lastRelease.version;
+	// Note: this is only set is a current multi-semantic-release released
+	const lastVersionForCurrentRelease = pkg._lastRelease && pkg._lastRelease.version;
+
+	// Ensure options don't have a conflict
+	const normalizedOptions = options || {};
+	if (normalizedOptions.tags && normalizedOptions.useGitTags) {
+		throw new Error("You can only separately provide a set of tags or specify useGitTags!");
+	}
+	let { tags = [] } = normalizedOptions;
+	const { useGitTags } = normalizedOptions;
 
 	// Extract tags:
 	// 1. Set filter to extract only package tags
@@ -59,7 +83,7 @@ const getNextPreVersion = (pkg, tags) => {
 	// 3. Resolve the versions from the tags
 	// TODO: replace {cwd: '.'} with multiContext.cwd
 	if (pkg.name) tagFilters.push(pkg.name);
-	if (!tags) {
+	if (useGitTags) {
 		try {
 			tags = getTags(pkg._branch, { cwd: process.cwd() }, tagFilters);
 		} catch (e) {
@@ -69,15 +93,15 @@ const getNextPreVersion = (pkg, tags) => {
 		}
 	}
 
-	const lastPreRelTag = getPreReleaseTag(lastVersion);
+	const lastPreRelTag = getPreReleaseTag(lastVersionForCurrentRelease);
 	const isNewPreRelTag = lastPreRelTag && lastPreRelTag !== pkg._preRelease;
 
 	const versionToSet =
-		isNewPreRelTag || !lastVersion
+		isNewPreRelTag || !lastVersionForCurrentRelease
 			? `1.0.0-${pkg._preRelease}.1`
 			: _nextPreVersionCases(
 					tags.map((tag) => getVersionFromTag(pkg, tag)).filter((tag) => tag),
-					lastVersion,
+					lastVersionForCurrentRelease,
 					pkg._nextType,
 					pkg._preRelease
 			  );
@@ -101,23 +125,23 @@ const getPreReleaseTag = (version) => {
 /**
  * Resolve next prerelease special cases: highest version from tags or major/minor/patch.
  *
- * @param {Array} tags List of all released tags from package.
- * @param {string} lastVersion Last package version released.
+ * @param {Array<string>} tags - if non-empty, we will use these tags as part fo the comparison
+ * @param {string} lastVersionForCurrentMultiRelease Last package version released from multi-semantic-release
  * @param {string} pkgNextType Next type evaluated for the next package type.
  * @param {string} pkgPreRelease Package prerelease suffix.
  * @returns {string|undefined} Next pkg version.
  * @internal
  */
-const _nextPreVersionCases = (tags, lastVersion, pkgNextType, pkgPreRelease) => {
+const _nextPreVersionCases = (tags, lastVersionForCurrentMultiRelease, pkgNextType, pkgPreRelease) => {
 	// Case 1: Normal release on last version and is now converted to a prerelease
-	if (!semver.prerelease(lastVersion)) {
-		const { major, minor, patch } = semver.parse(lastVersion);
+	if (!semver.prerelease(lastVersionForCurrentMultiRelease)) {
+		const { major, minor, patch } = semver.parse(lastVersionForCurrentMultiRelease);
 		return `${semver.inc(`${major}.${minor}.${patch}`, pkgNextType || "patch")}-${pkgPreRelease}.1`;
 	}
 
 	// Case 2: Validates version with tags
 	const latestTag = getLatestVersion(tags, { withPrerelease: true });
-	return _nextPreHighestVersion(latestTag, lastVersion, pkgPreRelease);
+	return _nextPreHighestVersion(latestTag, lastVersionForCurrentMultiRelease, pkgPreRelease);
 };
 
 /**


### PR DESCRIPTION
<!-- 
Add a link to issue, another PR, discussion with which this PR is associated.
Select the most suitable relation type: fixes / closes / relates
-->
Fixes [Issue 75](https://github.com/qiwi/multi-semantic-release/issues/75)

On Extensive debugging, the prerelease "next" logic that we use for bumping dependencies is disregarding the "_lastRelease" on a package and biasing on the git tags.  This is an issue though, because we always end up having run the previous package's release thanks to the topo library, so there is a tag indicating the current release.  Our desired release is this tag though and not the next increment.  It is, however, the desired bump of the "_lastRelease" of that package.

## Changes

To fix this, we keep a light touch by augmenting getNextPreVersion to:

1. still consider tags if an explicit options flag is set
2. Only consider lastRelease if not.  (Which is the only way that it is used currently).

Since this is only actually used by the prerelease version and it is a well documented bug, the behavior of looking at tags is removed completely since _lastRelease should always be called by preceding packages and if not, would be handled by a failure in the preceding analyzeCommits.

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md) - There are no external changes
